### PR TITLE
Add .pre-commit-hooks.yaml file, delete flag from README.md

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: check-copyright
+  name: Check copyright notices
+  entry: check_copyright.py --verbose --replace
+  language: python
+  files: \.(py|c|h|cpp|hpp|ld|s|S)$
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Example of the .pre-commit-config.yaml file
   rev: v1.0.0
   hooks:
     - id: check-copyright
-      args: ['--config', 'ci/check_copyright_config.yaml', '--ignore', 'ci/ignore_list_copyright', '--replace', '--verbose']
+      args: ['--config', 'ci/check_copyright_config.yaml', '--ignore', 'ci/ignore_list_copyright']
 ```
 
 ## As CI

--- a/check_copyright.py
+++ b/check_copyright.py
@@ -254,7 +254,7 @@ def has_valid_copyright(file_name: str, mime: str, is_on_ignore: bool, config_se
             if args.debug:
                 print(f'{TERMINAL_GRAY}{e} in {file_name}{TERMINAL_RESET}')
         else:
-            if not args.check_only:
+            if not args.dry_run:
                 code_lines = replace_copyright(code_lines, year, line, mime, file_name)
             else:
                 raise NeedsToBeUpdated(file_name)
@@ -313,7 +313,7 @@ def has_valid_copyright(file_name: str, mime: str, is_on_ignore: bool, config_se
             detected_licenses.append((matches.group(1), comment.line_number()))
 
     if not is_on_ignore and not contains_any_copyright(comments, args):
-        if not args.check_only:
+        if not args.dry_run:
             code_lines = insert_copyright(code_lines, file_name, mime, config_section)
             print(f'"{file_name}": inserted copyright notice - please check the content and run commit again!')
         else:


### PR DESCRIPTION
Forgot to add .pre-commit-hooks.yaml. Also, we use --replace and --verbose flags in the entry, no need to set them in args (deleted from the readme.md).
Tested here https://gitlab.espressif.cn:6688/espressif/idf-component-manager/-/jobs/24790666. Also tested pre-commit, SPDX header added successfully.