### PR TITLE
Add Windows support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: check-copyright
   name: Check copyright notices
-  entry: check_copyright.py --verbose --replace
+  entry: check-copyright --verbose --replace
   language: python
   files: \.(py|c|h|cpp|hpp|ld|s|S)$
   require_serial: true

--- a/check_copyright.py
+++ b/check_copyright.py
@@ -461,7 +461,7 @@ def check_copyrights(args: argparse.Namespace, config: configparser.ConfigParser
     ignore_list = []
     updated_ignore_list = []
 
-    if args.ignore:
+    if os.path.isfile(args.ignore):
         with open(args.ignore, 'r') as f:
             ignore_list = [item.strip() for item in f.readlines()]
             updated_ignore_list = ignore_list.copy()

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setuptools.setup(
     url=URL,
     install_requires=REQUIRES,
     py_modules=['check_copyright'],
-    scripts=['check_copyright.py']
+    scripts=['check_copyright.py'],
+    entry_points={'console_scripts': ['check-copyright=check_copyright:main']},
 )


### PR DESCRIPTION
Pre-commit has problems with Windows. @[Anthony Sottile](https://stackoverflow.com/users/812183/anthony-sottile) helped me to [fix that problem](https://stackoverflow.com/a/73140567/12102318)

The main problem was that a path didn't have any Windows slashes - "Executable `C:UsersZavodny.cachepre-commitrepocdma6ks5py_env-defaultScriptspython.EXE` not found". And check-copyright test was failed, because pre-commit couldn't find python executable file