### PR TITLE
bump version to 1.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     description=SHORT_DESCRIPTION,
     long_description_content_type='text/markdown',
     license=LICENSE,
-    version='1.0.1',
+    version='1.0.2',
     author=AUTHOR,
     maintainer=MAINTAINER,
     author_email=EMAIL,


### PR DESCRIPTION
Fix for updating copyright if it contains only a single year is merged for some time. Let's bump the version and release a new version so it's available for use.