### PR TITLE
Update pyyaml version to the most recent one

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIRES = [
     'thefuzz == 0.19.0',
     'thefuzz[speedup] == 0.19.0; sys_platform != "win32"',
     # don't depend on python-Levenshtein on Windows, as it requires Microsoft C++ Build Tools to install
-    'pyyaml == 5.4.1',
+    'pyyaml == 6.0.1',
     'pathspec == 0.9.0'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     description=SHORT_DESCRIPTION,
     long_description_content_type='text/markdown',
     license=LICENSE,
-    version='1.0.2',
+    version='1.0.3',
     author=AUTHOR,
     maintainer=MAINTAINER,
     author_email=EMAIL,


### PR DESCRIPTION
# Description
Pyyaml version 5.4.3 started to throw deprecation error and attribute error in the CI regarding it's dependencies (cython). Version 6.0.1 does not have these issues anymore.