### PR TITLE
Fixed a bug where the check_opyright.py script failed when run on a clean git repo

### DIFF
--- a/check_copyright.py
+++ b/check_copyright.py
@@ -508,7 +508,7 @@ def check_copyrights(args: argparse.Namespace, config: configparser.ConfigParser
             continue
 
         # Is this file a new file
-        is_new_file = args.is_new_file[file_name]
+        is_new_file = args.is_new_file.get(file_name)
 
         if file_name in ignore_list:
             if args.verbose:


### PR DESCRIPTION
This commit fixes a bug reported in #12 where the check_copyright.py script failed when run on a repository with no changed/modified files on the git staging area.