### PR TITLE
fix: Fix header indentification for new files

### DIFF
--- a/check_copyright.py
+++ b/check_copyright.py
@@ -274,10 +274,11 @@ def has_valid_copyright(file_name: str, mime: str, is_on_ignore: bool, is_new_fi
         if matches:
             detected_notices.append((matches.group(1), comment.line_number()))
             try:
+                years = extract_years_from_espressif_notice(matches.group(1))
+                # The previous call not just detects the year but also indentifies right line with Espressif license
+                # and distiguishes between updating FileContributor and FileCopyright.
                 if is_new_file:
                     years = (0, None)
-                else:
-                    years = extract_years_from_espressif_notice(matches.group(1))
             except NotFound as e:
                 if args.verbose:
                     print(f'{TERMINAL_GRAY}Not an {e.thing} {file_name}:{comment.line_number()}{TERMINAL_RESET}')
@@ -301,10 +302,11 @@ def has_valid_copyright(file_name: str, mime: str, is_on_ignore: bool, is_new_fi
         if matches:
             detected_contributors.append((matches.group(1), comment.line_number()))
             try:
+                years = extract_years_from_espressif_notice(matches.group(1))
+                # The previous call not just detects the year but also indentifies right line with Espressif license
+                # and distiguishes between updating FileContributor and FileCopyright.
                 if is_new_file:
                     years = (0, None)
-                else:
-                    years = extract_years_from_espressif_notice(matches.group(1))
             except NotFound as e:
                 if args.debug:
                     print(f'{TERMINAL_GRAY}Not an {e.thing} {file_name}:{comment.line_number()}{TERMINAL_RESET}')


### PR DESCRIPTION
- Fixes a regression of https://github.com/espressif/check-copyright/pull/11.

### Issue description
1. New file is added where Espressif is not the copyright owner but just a contributor. 
2. `extract_years_from_espressif_notice()` is not called when checking the copyright owner.
3. As a result of 2, `NotFound` is not raised.
4. As a consequence of 3, the copyright owner will be updated to Espressif.

### Solution
- Allways call `extract_years_from_espressif_notice()` in order to identify if Espressif is copyright owner or contributor.
- For new files the year range can be updated after.

### How to test it
1. Create and activate a python environment where you install this package from this branch by `pip install -e .`.
2. Go to the ESP-IDF directory but don't activate the environment.
3. `git add` a new file where Espressif is a contributor. 
4. Run `python -m check_copyright -c ./tools/ci/check_copyright_config.yaml -r components/newlib/src/string/memcmp.c` where `memcmp.c` is the new file.

It can be tested with a header:

```
/*
 * SPDX-FileCopyrightText: 1994-2009 John Smith
 *
 * SPDX-License-Identifier: Apache-2.0
 *
 * SPDX-FileContributor: 2025 Espressif Systems (Shanghai) CO LTD
 */

The version from master will overwrite John Smith to Espressif.

```
